### PR TITLE
fix d6tflow unknown at import in targets/h5.py

### DIFF
--- a/d6tflow/targets/h5.py
+++ b/d6tflow/targets/h5.py
@@ -11,7 +11,7 @@ class H5PandasTarget(DataTarget):
         opts = {**{'key':'data'},**kwargs}
         return super().save(df, 'to_hdf', **opts)
 
-class H5KerasTarget(d6tflow.targets.DataTarget):
+class H5KerasTarget(DataTarget):
     def load(self, cached=False, **kwargs):
         return super().load(load_model, cached, **kwargs)
 


### PR DESCRIPTION
Since `DataTarget` is imported with a `as DataTarget` statement it causes conflict with the definition of H5KerasTarget -- d6tflow module unknown.